### PR TITLE
fix: add correct plugin name

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ module.exports = {
                     // or
                     // with options
                     {
-                        resolve: "gatsby-remark-grid",
+                        resolve: "gatsby-remark-images-grid",
                         options: {
                             className: "myCustomClassName",
                             gridGap: "20px",


### PR DESCRIPTION
It didn't work for me with the other plugin name. 

Unfortunately, the plugin itself working for me. It shows the images in one column, but doesn't apply a grid on it. Not sure if the plugin configuration works as well, because I have used a `className` option but didn't see it in the DOM.