### PR TITLE
Fixing naming without option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ module.exports = {
                 plugins: [
                     // Make CSS grids available
                     // without options
-                    "gatsby-remark-grid"
+                    "gatsby-remark-images-grid"
                     // or
                     // with options
                     {


### PR DESCRIPTION
This PR https://github.com/cedricdelpoux/gatsby-remark-images-grid/pull/2/

Fixed one naming issue in the readme, but left another unfixed.