### PR TITLE
Fix: Make it compatible with new Remark/Micromark

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = ({markdownAST}, pluginOptions) => {
     }
 
     const gridNode = {
-      type: "list",
+      type: "parent",
       data: {
         hName: "div",
         hProperties: {


### PR DESCRIPTION
This PR is based on my comment in here: [Cannot read property 'className' of undefined (gatsby-transformer-remark v4+)](https://github.com/gatsbyjs/gatsby/issues/31181#issuecomment-839323644)