### PR TITLE
Directly use `mdast-util-from-markdown`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 const visit = require("unist-util-visit")
-const unified = require("unified")
-const markdown = require("remark-parse")
+const fromMarkdown = require("mdast-util-from-markdown")
 
 module.exports = ({markdownAST}, pluginOptions) => {
   visit(markdownAST, "code", (node) => {
@@ -18,7 +17,7 @@ module.exports = ({markdownAST}, pluginOptions) => {
       columnsCount = 1
     }
 
-    const contentAST = unified().use(markdown).parse(node.value)
+    const contentAST = fromMarkdown(node.value)
 
     let imagesNodes = []
 


### PR DESCRIPTION
I propose to directly use `mdast-util-from-markdown` instead `remark-parse` so the syntax is more simple and does not need `unified`